### PR TITLE
Fix expression for alpha calculation

### DIFF
--- a/src/local_fennel.jl
+++ b/src/local_fennel.jl
@@ -127,7 +127,8 @@ function local_fennel_sim(G::Vector{Vector{Int}}, locations::Matrix{Float64}, nu
 
     gamma = 2.0
     num_edges = sum([length(val) for val in G])
-    alpha = 0.5 * num_edges * ((num_p^(gamma - 1)) / (num_edges^(gamma)))
+    num_vertices = length(G)
+    alpha = 0.5 * num_edges * ((num_p^(gamma - 1)) / (num_vertices^(gamma)))
 
     to_cons = 5
     if num_p < 5


### PR DESCRIPTION
According to Fennel paper, $\alpha$ calculation should be

![image](https://github.com/TrainOfCode/LocalFennelPartitioning.jl/assets/32546500/6432ab62-de75-402c-9ec4-fcb8ab9e332f)

In the current implementation, `n` has been replaced by `num_edges` where the correct value should be `num_vertices`.

Fixed it.

@TrainOfCode 